### PR TITLE
Update Maven plugins

### DIFF
--- a/idp-authn-impl-shibsp/pom.xml
+++ b/idp-authn-impl-shibsp/pom.xml
@@ -225,7 +225,9 @@ THE SOFTWARE.
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
                     <tarLongFileMode>posix</tarLongFileMode>
-                    <descriptor>src/main/assembly/dep.xml</descriptor>
+                    <descriptors>
+                        <descriptor>src/main/assembly/dep.xml</descriptor>
+                    </descriptors>
                     <finalName>shibboleth-idp-authn-shibsp-${project.version}</finalName>
                     <appendAssemblyId>false</appendAssemblyId>
                     <outputDirectory>../target</outputDirectory>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@ THE SOFTWARE.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.version>3.5.1</maven.compiler.version>
+        <maven.compiler.version>3.8.1</maven.compiler.version>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
         <shib.idp.version>3.4.1</shib.idp.version>
@@ -338,11 +338,11 @@ THE SOFTWARE.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.10</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -362,12 +362,12 @@ THE SOFTWARE.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.10.3</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>3.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
- maven-assembly-plugin    2.5.5  -> 3.2.0
- maven-compiler-plugin    3.5.1  -> 3.8.1
- maven-dependency-plugin  2.10   -> 3.1.1
- maven-javadoc-plugin     2.10.3 -> 3.1.1
- maven-release-plugin     2.5.3  -> 3.0.0-M1

Fixes: mpassid/shibboleth-idp-authn-shibsp#1